### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Developers find ateam-mcp through:
 | `adas_redeploy` | Push changes live — regenerates MCP servers, deploys to ADAS Core |
 | `adas_solution_chat` | Talk to the Solution Bot for guided modifications |
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ariekogan-ateam-mcp).
+
 ## Setup
 
 ```bash


### PR DESCRIPTION
Adds a short note in the README that a hosted deployment is available on Fronteir AI.